### PR TITLE
Change .replace to use regex

### DIFF
--- a/src/crystallize/map-product.ts
+++ b/src/crystallize/map-product.ts
@@ -42,8 +42,8 @@ export const mapProduct = (product: ShopifyProduct): JSONProduct => {
     topics: [...collectionTopics, ...tagTopics],
     parentCataloguePath: `/${product.productType
       .toLowerCase()
-      .replace(' ', '-')
-      .replace('_', '')}`,
+      .replace(/ /g, '-')
+      .replace(/_/g, '')}`,
     components: {
       vendor: product.vendor,
       description: {


### PR DESCRIPTION
This fixes a folder mapping bug that doesn't associate products to folders with more that one SPACE is their name.